### PR TITLE
Refactor Props and Functions, Use userId in Firestore Collections

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,7 +9,7 @@ export const updateMessageStatus = onSchedule(
     const firestore = admin.firestore();
     const now = new Date();
 
-    const messagesRef = firestore.collectionGroup('messages');
+    const messagesRef = firestore.collection('messages');
 
     try {
       const query = messagesRef

--- a/src/app/apps/broadcasts/BroadcastsPage.tsx
+++ b/src/app/apps/broadcasts/BroadcastsPage.tsx
@@ -3,7 +3,7 @@ import BroadcastTable from './components/BroadcastsTable';
 
 export default function BroadcastPage() {
   return (
-    <Body title="Broadcasts">
+    <Body title="Transmissões">
       <BroadcastTable />
     </Body>
   );

--- a/src/app/apps/broadcasts/BroadcastsPage.tsx
+++ b/src/app/apps/broadcasts/BroadcastsPage.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
 import { Body } from '@/app/components/layout/Body';
 import BroadcastTable from './components/BroadcastsTable';
 
-const BroadcastPage: React.FC = () => {
+export default function BroadcastPage() {
   return (
     <Body title="Broadcasts">
       <BroadcastTable />
     </Body>
   );
-};
-
-export default BroadcastPage;
+}

--- a/src/app/apps/broadcasts/components/BroadcastsForm.tsx
+++ b/src/app/apps/broadcasts/components/BroadcastsForm.tsx
@@ -22,18 +22,14 @@ type FormData = z.infer<typeof formSchema>;
 
 interface BroadcastFormProps {
   onSubmit: (values: FormData) => void;
-  loading?: boolean;
   defaultValues?: FormData;
   contacts: Omit<Contact, 'phone'>[];
   connections: Connection[];
 }
 
-export const BroadcastForm: React.FC<BroadcastFormProps> = ({
-  onSubmit,
-  defaultValues,
-  contacts,
-  connections,
-}) => {
+export function BroadcastForm(props: BroadcastFormProps): React.ReactNode {
+  const { onSubmit, defaultValues, contacts, connections } = props;
+
   const {
     handleSubmit,
     register,
@@ -133,4 +129,4 @@ export const BroadcastForm: React.FC<BroadcastFormProps> = ({
       />
     </form>
   );
-};
+}

--- a/src/app/apps/broadcasts/components/BroadcastsModal.tsx
+++ b/src/app/apps/broadcasts/components/BroadcastsModal.tsx
@@ -7,10 +7,11 @@ import { Broadcast, createBroadcast } from '../BroadcastsModel';
 import { Contact } from '../../contacts/ContactsModel';
 import { Connection } from '../../connections/ConnectionsModel';
 import { Timestamp } from 'firebase/firestore';
+import { useAuth } from '../../auth/useAuth';
 
 type EditableBroadcastFields = Omit<
   Broadcast,
-  'id' | 'createdAt' | 'scheduledAt'
+  'id' | 'createdAt' | 'scheduledAt' | 'userId'
 > & {
   scheduledAt: Date;
   connectionName?: string;
@@ -44,13 +45,16 @@ export default function BroadcastModal({
 }: BroadcastModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { showAlert } = useAlert();
+  const { user } = useAuth();
 
   const handleBroadcastSubmission = useCallback(
     async (broadcastData: EditableBroadcastFields) => {
       try {
         setIsSubmitting(true);
 
-        await createBroadcast({
+        if (!user) throw new Error('Usuário não encontrado!');
+
+        await createBroadcast(user.uid, {
           ...broadcastData,
           scheduledAt: Timestamp.fromDate(broadcastData.scheduledAt),
         });

--- a/src/app/apps/broadcasts/components/BroadcastsModalActions.tsx
+++ b/src/app/apps/broadcasts/components/BroadcastsModalActions.tsx
@@ -1,32 +1,36 @@
 import { CustomButton } from '@/app/components/ui';
 import { Save } from '@mui/icons-material';
+import React from 'react';
 
 interface BroadcastModalActionsProps {
   onClose: () => void;
   loading: boolean;
 }
 
-export const BroadcastModalActions: React.FC<BroadcastModalActionsProps> = ({
-  onClose,
-  loading,
-}) => (
-  <>
-    <CustomButton onClick={onClose} type="button" disabled={loading}>
-      Cancelar
-    </CustomButton>
-    <CustomButton
-      variant="contained"
-      loading={loading}
-      startIcon={<Save />}
-      onClick={() =>
-        document
-          .querySelector('form')
-          ?.dispatchEvent(
-            new Event('submit', { cancelable: true, bubbles: true }),
-          )
-      }
-    >
-      Salvar
-    </CustomButton>
-  </>
-);
+export function BroadcastModalActions(
+  props: BroadcastModalActionsProps,
+): React.ReactNode {
+  const { onClose, loading } = props;
+
+  return (
+    <>
+      <CustomButton onClick={onClose} type="button" disabled={loading}>
+        Cancelar
+      </CustomButton>
+      <CustomButton
+        variant="contained"
+        loading={loading}
+        startIcon={<Save />}
+        onClick={() =>
+          document
+            .querySelector('form')
+            ?.dispatchEvent(
+              new Event('submit', { cancelable: true, bubbles: true }),
+            )
+        }
+      >
+        Salvar
+      </CustomButton>
+    </>
+  );
+}

--- a/src/app/apps/broadcasts/components/BroadcastsTable.tsx
+++ b/src/app/apps/broadcasts/components/BroadcastsTable.tsx
@@ -6,6 +6,7 @@ import { useContacts } from '../../contacts/ContactsModel';
 import { useConnections } from '../../connections/ConnectionsModel';
 import { AddButton, CustomDialog, CustomTable } from '@/app/components/ui';
 import { deleteBroadcast } from '../BroadcastsModel';
+import { useAuth } from '../../auth/useAuth';
 
 const columns = [
   { id: 'name', label: 'Nome' },
@@ -16,9 +17,13 @@ const columns = [
 ];
 
 export default function BroadcastTable() {
-  const broadcasts = useBroadcasts();
-  const contacts = useContacts();
-  const connections = useConnections();
+  const { user } = useAuth();
+
+  if (!user) throw new Error('Usuário não encontrado!');
+
+  const broadcasts = useBroadcasts(user.uid);
+  const contacts = useContacts(user.uid);
+  const connections = useConnections(user.uid);
 
   const [openModal, setOpenModal] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);
@@ -63,11 +68,7 @@ export default function BroadcastTable() {
           <AddButton onClick={handleOpenCreateModal} />
         </div>
 
-        <CustomTable
-          columns={columns}
-          data={data}
-          loading={!broadcasts?.length}
-        />
+        <CustomTable columns={columns} data={data} loading={!broadcasts} />
 
         <BroadcastModal
           open={openModal}

--- a/src/app/apps/broadcasts/components/BroadcastsTable.tsx
+++ b/src/app/apps/broadcasts/components/BroadcastsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import BroadcastModal from './BroadcastsModal';
 import BroadcastTableActions from './BroadcastsTableActions';
 import { Broadcast, useBroadcasts } from '../BroadcastsModel';
@@ -15,7 +15,7 @@ const columns = [
   { id: 'actions', label: 'Ações' },
 ];
 
-const BroadcastTable: React.FC = () => {
+export default function BroadcastTable() {
   const broadcasts = useBroadcasts();
   const contacts = useContacts();
   const connections = useConnections();
@@ -91,6 +91,4 @@ const BroadcastTable: React.FC = () => {
       </div>
     </>
   );
-};
-
-export default BroadcastTable;
+}

--- a/src/app/apps/connections/ConnectionsPage.tsx
+++ b/src/app/apps/connections/ConnectionsPage.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
 import { Body } from '@/app/components/layout/Body';
 import ConnectionTable from './components/ConnectionsTable';
 
-const ConnectionPage: React.FC = () => {
+export default function ConnectionPage() {
   return (
     <Body title="Conexões">
       <ConnectionTable />
     </Body>
   );
-};
-
-export default ConnectionPage;
+}

--- a/src/app/apps/connections/components/ConnectionsForm.tsx
+++ b/src/app/apps/connections/components/ConnectionsForm.tsx
@@ -15,10 +15,9 @@ interface ConnectionFormProps {
   defaultValues?: FormData;
 }
 
-export const ConnectionForm: React.FC<ConnectionFormProps> = ({
-  onSubmit,
-  defaultValues,
-}) => {
+export function ConnectionForm(props: ConnectionFormProps): React.ReactNode {
+  const { onSubmit, defaultValues } = props;
+
   const {
     handleSubmit,
     register,
@@ -40,4 +39,4 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({
       />
     </form>
   );
-};
+}

--- a/src/app/apps/connections/components/ConnectionsModal.tsx
+++ b/src/app/apps/connections/components/ConnectionsModal.tsx
@@ -8,10 +8,11 @@ import {
   createConnection,
   upsertConnection,
 } from '../ConnectionsModel';
+import { useAuth } from '../../auth/useAuth';
 
 type EditableConnectionFields = Omit<
   Connection,
-  'id' | 'createdAt' | 'updatedAt'
+  'id' | 'createdAt' | 'updatedAt' | 'userId'
 >;
 
 type ConnectionModalProps = {
@@ -36,17 +37,18 @@ export default function ConnectionModal({
 }: ConnectionModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { showAlert } = useAlert();
+  const { user } = useAuth();
 
   const handleConnectionSubmission = useCallback(
     async (connectionData: EditableConnectionFields) => {
       try {
         setIsSubmitting(true);
 
-        if (connection?.id) {
+        if (!user) throw new Error('Usuário não encontrado!');
+
+        if (connection?.id)
           await upsertConnection(connection.id, connectionData);
-        } else {
-          await createConnection(connectionData);
-        }
+        else await createConnection(user.uid, connectionData);
 
         onClose();
       } catch (error) {

--- a/src/app/apps/connections/components/ConnectionsModalActions.tsx
+++ b/src/app/apps/connections/components/ConnectionsModalActions.tsx
@@ -6,27 +6,30 @@ interface ConnectionModalActionsProps {
   loading: boolean;
 }
 
-export const ConnectionModalActions: React.FC<ConnectionModalActionsProps> = ({
-  onClose,
-  loading,
-}) => (
-  <>
-    <CustomButton onClick={onClose} type="button" disabled={loading}>
-      Cancelar
-    </CustomButton>
-    <CustomButton
-      variant="contained"
-      loading={loading}
-      startIcon={<Save />}
-      onClick={() =>
-        document
-          .querySelector('form')
-          ?.dispatchEvent(
-            new Event('submit', { cancelable: true, bubbles: true }),
-          )
-      }
-    >
-      Salvar
-    </CustomButton>
-  </>
-);
+export function ConnectionModalActions(
+  props: ConnectionModalActionsProps,
+): React.ReactNode {
+  const { onClose, loading } = props;
+
+  return (
+    <>
+      <CustomButton onClick={onClose} type="button" disabled={loading}>
+        Cancelar
+      </CustomButton>
+      <CustomButton
+        variant="contained"
+        loading={loading}
+        startIcon={<Save />}
+        onClick={() =>
+          document
+            .querySelector('form')
+            ?.dispatchEvent(
+              new Event('submit', { cancelable: true, bubbles: true }),
+            )
+        }
+      >
+        Salvar
+      </CustomButton>
+    </>
+  );
+}

--- a/src/app/apps/connections/components/ConnectionsTable.tsx
+++ b/src/app/apps/connections/components/ConnectionsTable.tsx
@@ -7,6 +7,7 @@ import {
   deleteConnection,
 } from '../ConnectionsModel';
 import { AddButton, CustomDialog, CustomTable } from '@/app/components/ui';
+import { useAuth } from '../../auth/useAuth';
 
 const columns = [
   { id: 'name', label: 'Nome' },
@@ -14,7 +15,11 @@ const columns = [
 ];
 
 export default function ConnectionTable() {
-  const connections = useConnections();
+  const { user } = useAuth();
+
+  if (!user) throw new Error('Usuário não encontrado!');
+
+  const connections = useConnections(user.uid);
   const [selectedConnection, setSelectedConnection] =
     useState<Connection | null>(null);
   const [openModal, setOpenModal] = useState(false);

--- a/src/app/apps/connections/components/ConnectionsTable.tsx
+++ b/src/app/apps/connections/components/ConnectionsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import ConnectionModal from './ConnectionsModal';
 import ConnectionTableActions from './ConnectionsTableActions';
 import {
@@ -13,7 +13,7 @@ const columns = [
   { id: 'actions', label: 'Ações' },
 ];
 
-const ConnectionTable: React.FC = () => {
+export default function ConnectionTable() {
   const connections = useConnections();
   const [selectedConnection, setSelectedConnection] =
     useState<Connection | null>(null);
@@ -85,6 +85,4 @@ const ConnectionTable: React.FC = () => {
       </div>
     </>
   );
-};
-
-export default ConnectionTable;
+}

--- a/src/app/apps/contacts/ContactsPage.tsx
+++ b/src/app/apps/contacts/ContactsPage.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
 import { Body } from '@/app/components/layout/Body';
 import ContactTable from './components/ContactsTable';
 
-const ContactPage: React.FC = () => {
+export default function ContactPage() {
   return (
     <Body title="Contatos">
       <ContactTable />
     </Body>
   );
-};
-
-export default ContactPage;
+}

--- a/src/app/apps/contacts/components/ContactsForm.tsx
+++ b/src/app/apps/contacts/components/ContactsForm.tsx
@@ -16,10 +16,9 @@ interface ContactFormProps {
   defaultValues?: FormData;
 }
 
-export const ContactForm: React.FC<ContactFormProps> = ({
-  onSubmit,
-  defaultValues,
-}) => {
+export function ContactForm(props: ContactFormProps): React.ReactNode {
+  const { onSubmit, defaultValues } = props;
+
   const {
     handleSubmit,
     register,
@@ -50,4 +49,4 @@ export const ContactForm: React.FC<ContactFormProps> = ({
       />
     </form>
   );
-};
+}

--- a/src/app/apps/contacts/components/ContactsModal.tsx
+++ b/src/app/apps/contacts/components/ContactsModal.tsx
@@ -4,8 +4,13 @@ import { useAlert } from '@/app/apps/alert/AlertProvider';
 import { ContactForm } from './ContactsForm';
 import { ContactModalActions } from './ContactsModalActions';
 import { Contact, createContact, upsertContact } from '../ContactsModel';
+import { useAuth } from '../../auth/useAuth';
 
-type EditableContactFields = Omit<Contact, 'id' | 'createdAt' | 'updatedAt'>;
+type EditableContactFields = Omit<
+  Contact,
+  'id' | 'createdAt' | 'updatedAt' | 'userId'
+>;
+
 type ContactModalProps = {
   open: boolean;
   onClose: () => void;
@@ -27,14 +32,17 @@ export default function ContactModal({
 }: ContactModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { showAlert } = useAlert();
+  const { user } = useAuth();
 
   const handleContactSubmission = useCallback(
     async (contactData: EditableContactFields) => {
       try {
         setIsSubmitting(true);
 
+        if (!user) throw new Error('Usuário não encontrado!');
+
         if (contact?.id) await upsertContact(contact.id, contactData);
-        else await createContact(contactData);
+        else await createContact(user.uid, contactData);
 
         onClose();
       } catch (error) {

--- a/src/app/apps/contacts/components/ContactsModalActions.tsx
+++ b/src/app/apps/contacts/components/ContactsModalActions.tsx
@@ -6,27 +6,30 @@ interface ContactModalActionsProps {
   loading: boolean;
 }
 
-export const ContactModalActions: React.FC<ContactModalActionsProps> = ({
-  onClose,
-  loading,
-}) => (
-  <>
-    <CustomButton onClick={onClose} type="button" disabled={loading}>
-      Cancelar
-    </CustomButton>
-    <CustomButton
-      variant="contained"
-      loading={loading}
-      startIcon={<Save />}
-      onClick={() =>
-        document
-          .querySelector('form')
-          ?.dispatchEvent(
-            new Event('submit', { cancelable: true, bubbles: true }),
-          )
-      }
-    >
-      Salvar
-    </CustomButton>
-  </>
-);
+export function ContactModalActions(
+  props: ContactModalActionsProps,
+): React.ReactNode {
+  const { onClose, loading } = props;
+
+  return (
+    <>
+      <CustomButton onClick={onClose} type="button" disabled={loading}>
+        Cancelar
+      </CustomButton>
+      <CustomButton
+        variant="contained"
+        loading={loading}
+        startIcon={<Save />}
+        onClick={() =>
+          document
+            .querySelector('form')
+            ?.dispatchEvent(
+              new Event('submit', { cancelable: true, bubbles: true }),
+            )
+        }
+      >
+        Salvar
+      </CustomButton>
+    </>
+  );
+}

--- a/src/app/apps/contacts/components/ContactsTable.tsx
+++ b/src/app/apps/contacts/components/ContactsTable.tsx
@@ -12,8 +12,11 @@ const columns = [
 ];
 
 export default function ContactTable() {
-  const userId = useAuth().user?.uid || '';
-  const contacts = useContacts(userId);
+  const { user } = useAuth();
+
+  if (!user) throw new Error('Usuário não encontrado!');
+
+  const contacts = useContacts(user.uid);
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
   const [openModal, setOpenModal] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);

--- a/src/app/apps/contacts/components/ContactsTable.tsx
+++ b/src/app/apps/contacts/components/ContactsTable.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import ContactModal from './ContactsModal';
 import ContactTableActions from './ContactsTableActions';
 import { Contact, deleteContact, useContacts } from '../ContactsModel';
 import { AddButton, CustomDialog, CustomTable } from '@/app/components/ui';
+import { useAuth } from '../../auth/useAuth';
 
 const columns = [
   { id: 'name', label: 'Nome' },
@@ -10,8 +11,9 @@ const columns = [
   { id: 'actions', label: 'Ações' },
 ];
 
-const ContactTable: React.FC = () => {
-  const contacts = useContacts();
+export default function ContactTable() {
+  const userId = useAuth().user?.uid || '';
+  const contacts = useContacts(userId);
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
   const [openModal, setOpenModal] = useState(false);
   const [openDialog, setOpenDialog] = useState(false);
@@ -82,6 +84,4 @@ const ContactTable: React.FC = () => {
       </div>
     </>
   );
-};
-
-export default ContactTable;
+}

--- a/src/app/apps/dashboard/DashboardPage.tsx
+++ b/src/app/apps/dashboard/DashboardPage.tsx
@@ -14,13 +14,21 @@ import {
   WhatsApp,
 } from '@mui/icons-material';
 import { useContactsCount } from '../contacts/ContactsModel';
+import { useAuth } from '../auth/useAuth';
 
 function Dashboard() {
-  const contactCount = useContactsCount();
-  const connectionCount = useConnectionsCount();
-  const broadcastCount = useBroadcastsCount();
-  const messageCountScheduled = useMessagesCount(StatusMessage.Scheduled);
-  const messageCountSent = useMessagesCount(StatusMessage.Sent);
+  const { user } = useAuth();
+
+  if (!user) throw new Error('Usuário não encontrado!');
+
+  const contactCount = useContactsCount(user.uid);
+  const connectionCount = useConnectionsCount(user.uid);
+  const broadcastCount = useBroadcastsCount(user.uid);
+  const messageCountScheduled = useMessagesCount(
+    user.uid,
+    StatusMessage.Scheduled,
+  );
+  const messageCountSent = useMessagesCount(user.uid, StatusMessage.Sent);
 
   const cardsData = [
     {

--- a/src/app/apps/messages/MessagesPage.tsx
+++ b/src/app/apps/messages/MessagesPage.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
 import { Body } from '@/app/components/layout/Body';
 import MessageTable from './components/MessagesTable';
 
-const MessagePage: React.FC = () => {
+export default function MessagePage() {
   return (
     <Body title="Mensagens">
       <MessageTable />
     </Body>
   );
-};
-
-export default MessagePage;
+}

--- a/src/app/apps/messages/components/MessagesTable.tsx
+++ b/src/app/apps/messages/components/MessagesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Chip } from '@mui/material';
 import { Message, StatusMessage, getMessages$ } from '../MessagesModel';
 import { CustomTable, StatusFilter } from '@/app/components/ui';
@@ -40,7 +40,7 @@ const processTableData = (messages: Message[]) =>
     status: renderStatusChip(message.status),
   }));
 
-const MessageTable: React.FC = () => {
+export default function MessageTable() {
   const [statusFilter, setStatusFilter] = useState<StatusMessage>(
     StatusMessage.Scheduled,
   );
@@ -69,6 +69,4 @@ const MessageTable: React.FC = () => {
       <CustomTable columns={columns} data={data} loading={loading} />
     </div>
   );
-};
-
-export default MessageTable;
+}

--- a/src/app/apps/messages/components/MessagesTable.tsx
+++ b/src/app/apps/messages/components/MessagesTable.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Chip } from '@mui/material';
 import { Message, StatusMessage, getMessages$ } from '../MessagesModel';
 import { CustomTable, StatusFilter } from '@/app/components/ui';
+import { useAuth } from '../../auth/useAuth';
 
 const columns = [
   { id: 'contactName', label: 'Contato' },
@@ -46,14 +47,20 @@ export default function MessageTable() {
   );
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
+  const { user } = useAuth();
 
   useEffect(() => {
     setLoading(true);
-    const subscription = getMessages$(statusFilter).subscribe(async (msgs) => {
-      const resolvedMessages = await Promise.all(msgs);
-      setMessages(resolvedMessages);
-      setLoading(false);
-    });
+
+    if (!user) throw new Error('Usuário não encontrado!');
+
+    const subscription = getMessages$(user.uid, statusFilter).subscribe(
+      async (msgs) => {
+        const resolvedMessages = await Promise.all(msgs);
+        setMessages(resolvedMessages);
+        setLoading(false);
+      },
+    );
 
     return () => subscription.unsubscribe();
   }, [statusFilter]);


### PR DESCRIPTION
## Features

- [x] Replaced arrow functions with named `function` declarations  
- [x] Updated Firestore collections to use `userId` for data scoping
